### PR TITLE
'Nice' release by default, correct exception for non-blocking acquires

### DIFF
--- a/mongoelector/locker.py
+++ b/mongoelector/locker.py
@@ -67,8 +67,10 @@ class MongoLocker(object):
 
     @staticmethod
     def _acquireretry(blocking, start, timeout, count):
-        if blocking is False and count > 0:
-            return False
+        if blocking is False:
+            if count > 0:
+                return False
+            return True
         if blocking is True and count == 0:
             return True
         if timeout:
@@ -189,7 +191,7 @@ class MongoLocker(object):
         even if the local instance isn't the lock owner.
         :type force: bool
         '''
-        if not force:
+        if force:
             query = {'_id': self.key,}
         else:
             query = {'_id': self.key,

--- a/tests/test_mongolocker.py
+++ b/tests/test_mongolocker.py
@@ -13,7 +13,7 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 
-from mongoelector import MongoLocker
+from mongoelector import MongoLocker, LockExists
 from pymongo import MongoClient
 
 import unittest
@@ -54,6 +54,19 @@ class TestMongoLocker(unittest.TestCase):
         ml = MongoLocker('testinit', db, timeparanoid=True)
         ml._verifytime()
 
+    def test_004_force_release(self):
+        db = MongoClient()
+        ml1 = MongoLocker('testrelease', db)
+        ml2 = MongoLocker('testrelease', db)
+        ml1.acquire()
+        with self.assertRaises(LockExists):
+            ml2.acquire(blocking=False)
+        ml2.release()
+        self.assertTrue(ml1.locked())
+        self.assertTrue(ml1.owned())
+        ml2.release(force=True)
+        self.assertFalse(ml1.locked())
+        self.assertFalse(ml1.owned())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Correct a couple issues:

`release` method behavior deviates from stated contract, releases all locks unless `force=True` is passed in
`acquire` method raises `AcquireTimeout` when non-blocking acquire is called against db with existing lock

Added unittest for the lock release issue, can add explicit test for blocking/non-blocking acquire calls if necessary.